### PR TITLE
lib/meta: Remove evalConstraints & intermediate bool constraint attrsets

### DIFF
--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -253,6 +253,8 @@ rec {
     ) platform
   );
 
+  platform = import ./platform-constraints.nix { inherit lib; };
+
   /**
     Check if a package is available on a given platform.
 

--- a/lib/platform-constraints.nix
+++ b/lib/platform-constraints.nix
@@ -1,0 +1,70 @@
+{ lib }:
+
+# This defines an algebra to express platform constraints using AND, OR and NOT
+# which behave like boolean operators but for platform properties.
+#
+# Examples:
+#
+# with lib.meta.platform.constraints;
+# OR [
+#   isLinux
+#   isDarwin
+# ]
+#
+# with lib.meta.platform.constraints;
+# AND [
+#   (OR [
+#     isLinux
+#     isDarwin
+#   ])
+#   (OR [
+#     isx86
+#     isAarch
+#   ])
+#   (NOT isMusl)
+# ]
+
+{
+  constraints =
+    {
+      OR = value: {
+        __operation = "OR";
+        inherit value;
+      };
+      AND = value: {
+        __operation = "AND";
+        inherit value;
+      };
+      NOT = value: {
+        __operation = "NOT";
+        value = [ value ]; # Also make this a list for simplicity
+      };
+    }
+    # Put patterns in this set for convenient use
+    // lib.systems.inspect.patterns
+    # Platform patterns too. We can just do this because platforms (i.e. `hostPlatform`) have all of these
+    # mashed together too.
+    // lib.systems.inspect.platformPatterns;
+
+  # Evaluates a platform constraints expression down into a boolean value
+  # similar to how lib.meta.platformMatch performs checks a single constraint.
+  # Because this uses lib.meta.platformMatch internally it supports the same set
+  # of platform constraints.
+  evalConstraints =
+    platform: initialValue:
+    let
+      operations = {
+        OR = lib.any lib.id;
+        AND = lib.all lib.id;
+        NOT = x: !(lib.head x); # We have a list with one value
+      };
+      platformMatch' = lib.meta.platformMatch platform;
+      recurse =
+        expression:
+        if expression ? __operation then
+          operations.${expression.__operation} (map recurse expression.value)
+        else
+          platformMatch' expression;
+    in
+    recurse initialValue;
+}

--- a/lib/platform-constraints.nix
+++ b/lib/platform-constraints.nix
@@ -31,10 +31,13 @@ in
 
 rec {
   constraints =
-    {
+    rec {
       OR = fns: platform: any (fn: fn platform) fns;
       AND = fns: platform: all (fn: fn platform) fns;
       NOT = fn: platform: !fn platform;
+
+      ANY = makeConstraint { };
+      NONE = NOT ANY;
     }
     # Put patterns in this set for convenient use
     // lib.mapAttrs (_: makeConstraint) lib.systems.inspect.patterns

--- a/lib/platform-constraints.nix
+++ b/lib/platform-constraints.nix
@@ -29,16 +29,18 @@ let
 
 in
 
-{
+rec {
   constraints =
     {
       OR = fns: platform: any (fn: fn platform) fns;
       AND = fns: platform: all (fn: fn platform) fns;
-      NOT = fn: platform: ! fn platform;
+      NOT = fn: platform: !fn platform;
     }
     # Put patterns in this set for convenient use
-    // lib.mapAttrs (_: pattern: platform: platformMatch platform pattern) lib.systems.inspect.patterns
+    // lib.mapAttrs (_: makeConstraint) lib.systems.inspect.patterns
     # Platform patterns too. We can just do this because platforms (i.e. `hostPlatform`) have all of these
     # mashed together too.
-    // lib.mapAttrs (_: pattern: platform: platformMatch platform pattern) lib.systems.inspect.platformPatterns;
+    // lib.mapAttrs (_: makeConstraint) lib.systems.inspect.platformPatterns;
+
+  makeConstraint = pattern: platform: platformMatch platform pattern;
 }

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -139,7 +139,7 @@ let
 
 in
 
-runTests {
+runTests ({
 
 # CUSTOMIZATION
 
@@ -2467,6 +2467,64 @@ runTests {
     expr = meta.platformMatch { } "x86_64-linux";
     expected = false;
   };
+}
+// (let
+  exampleSystem = lib.systems.elaborate "aarch64-darwin";
+in {
+  test_evalPatternMatch_AND = {
+    expr =
+      with lib.meta.platform.constraints;
+      lib.meta.platform.evalConstraints exampleSystem (AND [ is64bit is32bit ]);
+    expected = false;
+  };
+  test_evalPatternMatch_AND_is_noop = {
+    expr =
+      with lib.meta.platform.constraints;
+      lib.meta.platform.evalConstraints exampleSystem (AND [ is64bit ]);
+    expected = true;
+  };
+  test_evalPatternMatch_OR = {
+    expr =
+      with lib.meta.platform.constraints;
+      lib.meta.platform.evalConstraints exampleSystem (OR [ is64bit is32bit ]);
+    expected = true;
+  };
+  test_evalPatternMatch_OR_is_noop = {
+    expr =
+      with lib.meta.platform.constraints;
+      lib.meta.platform.evalConstraints exampleSystem (OR [ is64bit ]);
+    expected = true;
+  };
+  test_evalPatternMatch_NOT = {
+    expr =
+      with lib.meta.platform.constraints;
+      lib.meta.platform.evalConstraints exampleSystem (NOT is64bit);
+    expected = false;
+  };
+}) // lib.mapAttrs' (system: expected:
+  lib.nameValuePair "test_evalPatternMatch_nested_combination_${system}" {
+    expr =
+      with lib.meta.platform.constraints;
+      lib.meta.platform.evalConstraints (lib.systems.elaborate system) (AND [
+        (NOT is32bit)
+        (OR [
+          isLinux
+          isFreeBSD
+        ])
+      ]);
+    inherit expected;
+  }) {
+    aarch64-darwin = false;
+    aarch64-linux = true;
+    armv7l-linux = false;
+    armv7l-darwin = false;
+    x86_64-linux = true;
+    x86_64-freebsd = true;
+    aarch64-freebsd = true;
+    i686-freebsd = false;
+  }
+
+// {
 
   testPackagesFromDirectoryRecursive = {
     expr = packagesFromDirectoryRecursive {
@@ -2500,4 +2558,4 @@ runTests {
     };
     expected = "c";
   };
-}
+})

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -2474,44 +2474,50 @@ in {
   test_evalPatternMatch_AND = {
     expr =
       with lib.meta.platform.constraints;
-      lib.meta.platform.evalConstraints exampleSystem (AND [ is64bit is32bit ]);
+      (AND [ is64bit is32bit ])
+      exampleSystem;
     expected = false;
   };
   test_evalPatternMatch_AND_is_noop = {
     expr =
       with lib.meta.platform.constraints;
-      lib.meta.platform.evalConstraints exampleSystem (AND [ is64bit ]);
+      (AND [ is64bit ])
+      exampleSystem;
     expected = true;
   };
   test_evalPatternMatch_OR = {
     expr =
       with lib.meta.platform.constraints;
-      lib.meta.platform.evalConstraints exampleSystem (OR [ is64bit is32bit ]);
+      (OR [ is64bit is32bit ])
+      exampleSystem;
     expected = true;
   };
   test_evalPatternMatch_OR_is_noop = {
     expr =
       with lib.meta.platform.constraints;
-      lib.meta.platform.evalConstraints exampleSystem (OR [ is64bit ]);
+      (OR [ is64bit ])
+      exampleSystem;
     expected = true;
   };
   test_evalPatternMatch_NOT = {
     expr =
       with lib.meta.platform.constraints;
-      lib.meta.platform.evalConstraints exampleSystem (NOT is64bit);
+      (NOT is64bit)
+      exampleSystem;
     expected = false;
   };
 }) // lib.mapAttrs' (system: expected:
   lib.nameValuePair "test_evalPatternMatch_nested_combination_${system}" {
     expr =
       with lib.meta.platform.constraints;
-      lib.meta.platform.evalConstraints (lib.systems.elaborate system) (AND [
+      (AND [
         (NOT is32bit)
         (OR [
           isLinux
           isFreeBSD
         ])
-      ]);
+      ])
+      (lib.systems.elaborate system);
     inherit expected;
   }) {
     aarch64-darwin = false;
@@ -2523,7 +2529,6 @@ in {
     aarch64-freebsd = true;
     i686-freebsd = false;
   }
-
 // {
 
   testPackagesFromDirectoryRecursive = {


### PR DESCRIPTION
By "compiling" the constraints into a function taking the constraint to compute compatibility for.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
